### PR TITLE
Support use of type annotations in client code, allow protobuf>=3.20.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "protogen"
-version = "0.3.0"
+version = "0.3.1"
 description = "protogen makes writing protoc plugins easy."
 authors = ["fischor <fischor.sh@gmail.com>"]
 maintainers = ["fischor <fischor.sh@gmail.com>"]
@@ -18,7 +18,7 @@ keywords = [
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
-protobuf = "^3.20.3"
+protobuf = ">=3.20.3"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.9.6"


### PR DESCRIPTION
Great tool! Created a protoc plugin in an afternoon; much faster than last time I did one.

A couple of very small improvements:
* added `py.typed` as required by [PEP 561](https://peps.python.org/pep-0561) so that client code (and IDEs) can leverage the already present type annotations.
* relaxed the protobuf requirement to `protobuf>=3.20.3`. Ran all test with both 3.20.3 and the latest 4.23.2.
* bumped version to 0.3.1