### PR TITLE
Ensure imports are sorted

### DIFF
--- a/protogen/__init__.py
+++ b/protogen/__init__.py
@@ -1560,7 +1560,7 @@ class GeneratedFile:
 
     def _proto(self) -> google.protobuf.compiler.plugin_pb2.CodeGeneratorResponse.File:
         if self._import_mark > -1:
-            sorted_imports = sort(self._imports, key=lambda x:x._path, reverse=True)
+            sorted_imports = sorted(self._imports, key=lambda x:x._path, reverse=True)
             lines = (
                 self._buf[: self._import_mark]
                 + [f"import {p._path}" for p in sorted_imports]

--- a/protogen/__init__.py
+++ b/protogen/__init__.py
@@ -1560,7 +1560,7 @@ class GeneratedFile:
 
     def _proto(self) -> google.protobuf.compiler.plugin_pb2.CodeGeneratorResponse.File:
         if self._import_mark > -1:
-            sorted_imports = sorted(self._imports, key=lambda x:x._path, reverse=True)
+            sorted_imports = sorted(self._imports, key=lambda x:x._path)
             lines = (
                 self._buf[: self._import_mark]
                 + [f"import {p._path}" for p in sorted_imports]

--- a/protogen/__init__.py
+++ b/protogen/__init__.py
@@ -1560,7 +1560,7 @@ class GeneratedFile:
 
     def _proto(self) -> google.protobuf.compiler.plugin_pb2.CodeGeneratorResponse.File:
         if self._import_mark > -1:
-            sorted_imports = sorted(self._imports, key=lambda x:x._path)
+            sorted_imports = sorted(self._imports, key=lambda x: x._path)
             lines = (
                 self._buf[: self._import_mark]
                 + [f"import {p._path}" for p in sorted_imports]

--- a/protogen/__init__.py
+++ b/protogen/__init__.py
@@ -1560,9 +1560,10 @@ class GeneratedFile:
 
     def _proto(self) -> google.protobuf.compiler.plugin_pb2.CodeGeneratorResponse.File:
         if self._import_mark > -1:
+            sorted_imports = sort(self._imports, key=lambda x:x._path, reverse=True)
             lines = (
                 self._buf[: self._import_mark]
-                + [f"import {p._path}" for p in self._imports]
+                + [f"import {p._path}" for p in sorted_imports]
                 + self._buf[self._import_mark :]
             )
         else:


### PR DESCRIPTION
Currently protogen doesn't place them in order which makes it hard to make file generation reproducible as imports get re-ordered on every run. This sorts by path string on reverse so that inserts are the same on every run.