### PR TITLE
docs: fix references to print_import

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If they are from different Python modules, the arguments import path will be add
 
 If both files are from the same `PyImportPath`, then the import path is not added to the list of imports. In that case it is sufficient to reference the `PyIdent` by its simple name (e.g. `Timestamp`), thus only the `PyIdent.py_name` will be printed.
 
-To place the import statements in the buffer of the `GeneratedFile` use `GeneratedFile.print_imports`. This will put a line `"import <path>"` for each `PyImportPath` that the generated file needs to import (e.g `"import google.protobuf.timestamp_pb2"`) in the buffer.
+To place the import statements in the buffer of the `GeneratedFile` use `GeneratedFile.print_import`. This will put a line `"import <path>"` for each `PyImportPath` that the generated file needs to import (e.g `"import google.protobuf.timestamp_pb2"`) in the buffer.
 
 The following example shows how the `GeneratedFile.P` function behaves for different `PyImportPaths`::
 

--- a/protogen/__init__.py
+++ b/protogen/__init__.py
@@ -31,7 +31,7 @@ following example plugin:
             )
             g.P("# Generated code ahead.")
             g.P()
-            g.print_imports()
+            g.print_import()
             g.P()
             for m in f.message:
                 g.P("class ", m.py_ident, ":")
@@ -1411,7 +1411,7 @@ class GeneratedFile:
 
     Additionally, the generated file provides mechanism for handling Python
     imports.  Internally it maintains a list of :class:`PyImportPath` s that are
-    requested to be imported.  Use :meth:`print_imports` to mark the position in
+    requested to be imported.  Use :meth:`print_import` to mark the position in
     the output buffer the imports will be printed at.
 
     To create a new instance of a generated file use
@@ -1552,7 +1552,7 @@ class GeneratedFile:
         -------
         >>> g.P("# My python file")
         >>> g.P()
-        >>> g.print_imports()
+        >>> g.print_import()
         >>> g.P()
         >>> g.P("# more content following after the imports..")
         """


### PR DESCRIPTION
It's `print_import`, not `print_imports`.