### PR TITLE
Obey black

### DIFF
--- a/protogen/__init__.py
+++ b/protogen/__init__.py
@@ -26,7 +26,7 @@ following example plugin:
     def generate(gen: protogen.Plugin):
         for f in gen.files_to_generate:
             g = gen.new_generated_file(
-                f.proto.name.replace(".proto", ".py"), 
+                f.proto.name.replace(".proto", ".py"),
                 f.py_import_path,
             )
             g.P("# Generated code ahead.")

--- a/test/plugin/main.py
+++ b/test/plugin/main.py
@@ -94,7 +94,7 @@ def generate_extensions(g: protogen.GeneratedFile, e: protogen.Extension):
 
 
 def collect_messages(
-    fm: Union[protogen.File, protogen.Message]
+    fm: Union[protogen.File, protogen.Message],
 ) -> List[protogen.Message]:
     messages = []
     for m in fm.messages:


### PR DESCRIPTION
This gets things back to passing the 'lint' github action workflow. I just did `uvx black .`

---

This change is part of a trio. In combination with #19 and #20, github actions should go green again; this is working on my fork's 'actions' branch which merges the three: https://github.com/spenczar/protogen-python/actions/runs/15672639439/