### PR TITLE
Update github actions step versions

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -6,5 +6,5 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.2.2
       - uses: psf/black@stable

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -11,26 +11,26 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       - name: Setup Python
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v5.6.0
         with:
-          python-version: "3.8"
+          python-version: 3.13
       - name: python --version
         run: |
           python --version
           python3 --version
       - name: Setup protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3.0.0
         with:
-          version: "3.17.3"
+          version: "31.1"
       - name: protoc --version
         run: protoc --version
       - name: Permacache Poetry
         id: cache-poetry
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v4.2.3
         with:
           path: ~/.poetry
           key: poetry
@@ -57,7 +57,7 @@ jobs:
         run: poetry check --no-interaction
       - name: Cache dependencies
         id: cache-deps
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v4.2.3
         with:
           path: ${{github.workspace}}/.venv
           key: poetry-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4.2.2
       - name: Setup Python
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v5.6.0
         with:
-          python-version: "3.8"
+          python-version: "3.13"
       - name: Permacache Poetry
         id: cache-poetry
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v4.2.3
         with:
           path: ~/.poetry
           key: poetry
@@ -34,7 +34,7 @@ jobs:
         run: poetry check --no-interaction
       - name: Cache dependencies
         id: cache-deps
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v4.2.3
         with:
           path: ${{github.workspace}}/.venv
           key: poetry-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,25 +16,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4.2.2
       - name: Setup Python
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v5.6.0
         with:
-          python-version: 3.8
+          python-version: 3.13
       - name: python --version
         run: |
           python --version
           python3 --version
       - name: Setup protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3.0.0
         with:
-          version: "3.17.3"
+          version: "31.1"
       - name: protoc --version
         run: protoc --version
       # Perma-cache Poetry since we only need it for checking pyproject version
       - name: Cache Poetry
         id: cache-poetry
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v4.2.3
         with:
           path: ~/.poetry
           key: poetry
@@ -54,7 +54,7 @@ jobs:
         run: poetry check --no-interaction
       - name: Cache dependencies
         id: cache-deps
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v4.2.3
         with:
           path: ${{github.workspace}}/.venv
           key: deps-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
The `test` action workflow is currently failing because of this:

> This request has been automatically failed because it uses a deprecated version of `actions/cache: v2.1.6`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

For example, here: https://github.com/fischor/protogen-python/actions/runs/15662486874

This commit updates all pinned versions to their current latest release, which fixes that particular error.